### PR TITLE
Add script to deploy commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "src/index.js",
   "scripts": {
     "dev": "nodemon --watch src/ src/index.js",
+    "deploy-commands": "node scripts/deploy-commands.js",
     "start": "node src/index.js"
   },
   "repository": {

--- a/scripts/deploy-commands.js
+++ b/scripts/deploy-commands.js
@@ -1,0 +1,24 @@
+require('dotenv').config();
+const { REST, Routes } = require('discord.js');
+
+// This script currently deploys zero commands, serving as a proof of concept.
+// To deploy commands, populate the annotated array below.
+(async () => {
+  const rest = new REST().setToken(process.env.TOKEN);
+  // TODO: Populate this to deploy commands.
+  const commands = [];
+
+  try {
+    console.log('Deploying commands (/).');
+    await rest.put(
+      Routes.applicationGuildCommands(
+        process.env.CLIENT_ID,
+        process.env.GUILD_ID
+      ),
+      { body: commands }
+    );
+    console.log('Deployed commands (/) with zero (0) errors.');
+  } catch (e) {
+    console.error('Error deploying commands (/):', e.message);
+  }
+})();


### PR DESCRIPTION
This pull request enables the client to deploy its commands.

To achieve this, I:
- Added a script to deploy commands.

I am currently investigating implementing a more efficient method of registering and deploying commands, but due to the minute scope of this project, I may leave the script as-is for the foreseeable future and return later for refactoring.